### PR TITLE
Add unit tests for checking rest api functionality and example controller

### DIFF
--- a/src/main/java/com/study_buddy/study_buddy/config/SecurityConfig.java
+++ b/src/main/java/com/study_buddy/study_buddy/config/SecurityConfig.java
@@ -17,7 +17,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
-
 import java.util.List;
 
 @Configuration
@@ -28,19 +27,18 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> {
-                    auth.requestMatchers("/login/**", "/users/**", "/example", "/oauth2/**",
-                                    "/h2-console/**", "/favicon.ico").permitAll()
+                    auth.requestMatchers("/login/**", "/users/**", "/example/greeting",
+                            "/oauth2/**", "/h2-console/**", "/favicon.ico").permitAll()
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll(); // Allow OPTIONS
                     auth.anyRequest().authenticated();
                 })
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // Custom CORS configuration
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
-                .csrf(AbstractHttpConfigurer::disable) // Disable CSRF for testing??????????????????????????????????????????
-                .addFilterBefore(customHeaderFilter(), HeaderWriterFilter.class)  // Add the custom header filter
+                .csrf(AbstractHttpConfigurer::disable) // Disable CSRF for
+                                                       // testing??????????????????????????????????????????
+                .addFilterBefore(customHeaderFilter(), HeaderWriterFilter.class) // Add the custom header filter
                 .build();
     }
-
-
 
     @Bean
     public JwtDecoder jwtDecoder() {
@@ -60,9 +58,10 @@ public class SecurityConfig {
                 // Set X-Frame-Options to SAMEORIGIN
                 httpResponse.setHeader("X-Frame-Options", "SAMEORIGIN");
 
-                // Set Content-Security-Policy to allow framing only from same origin and localhost
-                httpResponse.setHeader("Content-Security-Policy", "frame-ancestors 'self' http://localhost:8080 https://accounts.google.com");
-
+                // Set Content-Security-Policy to allow framing only from same origin and
+                // localhost
+                httpResponse.setHeader("Content-Security-Policy",
+                        "frame-ancestors 'self' http://localhost:8080 https://accounts.google.com");
 
             }
             // Continue with the filter chain
@@ -84,6 +83,5 @@ public class SecurityConfig {
         return source;
 
     }
-
 
 }

--- a/src/main/java/com/study_buddy/study_buddy/controller/ExampleController.java
+++ b/src/main/java/com/study_buddy/study_buddy/controller/ExampleController.java
@@ -7,8 +7,13 @@ import java.util.Map;
 @RequestMapping("/example")
 public class ExampleController {
 
-    @GetMapping(produces = "application/json")
+    @GetMapping(value = "/greeting", produces = "application/json")
     public Map<String, String> getExample() {
         return Map.of("hello", "world");
+    }
+
+    @GetMapping(value = "/unauthorized", produces = "application/json")
+    public Map<String, String> getUnauthorizedExample() {
+        return Map.of("unauthorized", "world");
     }
 }

--- a/src/test/java/com/study_buddy/study_buddy/ExampleTest.java
+++ b/src/test/java/com/study_buddy/study_buddy/ExampleTest.java
@@ -1,0 +1,28 @@
+package com.study_buddy.study_buddy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import com.study_buddy.study_buddy.controller.ExampleController;
+
+@SpringBootTest
+class ExampleTest {
+
+	@Autowired
+	private ExampleController controller;
+
+	@Test
+	void contextLoads() {
+		assertThat(controller).isNotNull();
+	}
+
+	@Test
+	void exampleReturnsHelloWorld() throws Exception {
+		Map<String, String> helloWorld = Map.of("hello", "world");
+		assertThat(controller.getExample()).isEqualTo(helloWorld);
+	}
+}

--- a/src/test/java/com/study_buddy/study_buddy/RestApiTest.java
+++ b/src/test/java/com/study_buddy/study_buddy/RestApiTest.java
@@ -1,0 +1,47 @@
+package com.study_buddy.study_buddy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RestApiTest {
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Test
+	void exampleRestApiCallReturnsHelloWorld() throws Exception {
+		Map<String, String> helloWorld = Map.of("hello", "world");
+		// No need for a DTO because this is not a complex object
+		ResponseEntity<Map<String, String>> response = this.restTemplate.exchange(
+				"/example/greeting",
+				HttpMethod.GET,
+				null,
+				new ParameterizedTypeReference<>() {
+				});
+		assertThat(response.getBody()).isEqualTo(helloWorld);
+	}
+
+	// TODO: Create a mock for security config
+	//@Test
+	//void nonExistingEndpointReturnsNotFound() throws Exception {
+	//	ResponseEntity<String> response = this.restTemplate.getForEntity("/nonExistingEndpoint", String.class);
+	//	assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	//}
+
+	@Test
+	void unauthorizedEndpointReturnsUnauthorized() throws Exception {
+		ResponseEntity<String> response = this.restTemplate.getForEntity("/example/unauthorized", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+}


### PR DESCRIPTION
Adds unit tests for rest api functionality and the example controller. Updates example controller with /greeting and /unauthorized. 

Missing `nonExistingEndpointReturnsNotFound` integration test because we need to mock the security config to let us bypass oauth/our own security restrictions. This is needed because non-existing endpoints return 401 instead of 404 (even though they are exempt from security in SecurityConfig). It will also enable future tests for protected functionalities. I will add this in another PR.